### PR TITLE
fix: static shared instance, no getter

### DIFF
--- a/Sources/XMTPRust/ApiService.swift
+++ b/Sources/XMTPRust/ApiService.swift
@@ -9,7 +9,8 @@ import Foundation
 
 // The goal of this class is to provide a steady-ish Swift interface between Rust and xmtp-ios
 public class ApiService {
-    static let shared = ApiService()
+    // Public static shared instance
+    public static let shared = ApiService()
     
     let environment: String
     let secure: Bool
@@ -17,11 +18,6 @@ public class ApiService {
     public init(environment: String = "https://dev.xmtp.network", secure: Bool = true) {
         self.environment = environment
         self.secure = secure
-    }
-
-    // shared getter
-    public static func get() -> ApiService {
-        return ApiService.shared
     }
     
     // It's all strings all the time

--- a/Tests/XMTPRust-Tests/XMTPRust_Tests.swift
+++ b/Tests/XMTPRust-Tests/XMTPRust_Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 // See if we can use the XMTPRust library
 class XMTPRust_Tests: XCTestCase {
     func testExample() async throws {
-        let apiservice = XMTPRust.ApiService(environment: "http://localhost:15555", secure: false)
+        let apiservice = XMTPRust.ApiService(environment: "http://localhost:5556", secure: false)
         let queryResult = try await apiservice.query(topic: "test", json_paging_info: "")
         XCTAssertFalse(queryResult.isEmpty)
     }


### PR DESCRIPTION
## Overview

Address PR feedback from #1 to make things more Swifty. NOTE: this will break the API used in https://github.com/xmtp/xmtp-ios/tree/michaelx-rust_sdk_integration

## Test Plan

- Unit test, also fixed the port